### PR TITLE
Fix buying a single artefact

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,7 +3,20 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="TestOcrHelper">
-        <State />
+        <State>
+          <targetSelectedWithDropDown>
+            <Target>
+              <type value="QUICK_BOOT_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="C:\Users\Motte\.android\avd\Pixel_7_API_33.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </targetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-02-25T20:59:11.564689900Z" />
+        </State>
       </entry>
       <entry key="TestScreenshotHelper">
         <State />
@@ -41,20 +54,7 @@
         </State>
       </entry>
       <entry key="app">
-        <State>
-          <targetSelectedWithDropDown>
-            <Target>
-              <type value="QUICK_BOOT_TARGET" />
-              <deviceKey>
-                <Key>
-                  <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="C:\Users\Motte\.android\avd\Pixel_7_API_33.avd" />
-                </Key>
-              </deviceKey>
-            </Target>
-          </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-02-23T23:58:14.922115200Z" />
-        </State>
+        <State />
       </entry>
     </value>
   </component>

--- a/app/src/main/java/bhg/sucks/helper/OcrHelper.java
+++ b/app/src/main/java/bhg/sucks/helper/OcrHelper.java
@@ -161,8 +161,10 @@ public class OcrHelper {
 
                     Point p = isConfirmAvailable(textBlocks);
 
-                    // Fix to not hit 'buy single artefact', but 'buy 5 artefacts'
-                    p.set(p.x + 50, p.y);
+                    if (p != null) {
+                        // Fix to not hit 'buy single artefact', but 'buy 5 artefacts'
+                        p.set(p.x + 50, p.y);
+                    }
 
                     handlePoint.accept(p);
                 });

--- a/app/src/main/java/bhg/sucks/helper/OcrHelper.java
+++ b/app/src/main/java/bhg/sucks/helper/OcrHelper.java
@@ -160,6 +160,10 @@ public class OcrHelper {
                     List<Text.TextBlock> textBlocks = visionText.getTextBlocks();
 
                     Point p = isConfirmAvailable(textBlocks);
+
+                    // Fix to not hit 'buy single artefact', but 'buy 5 artefacts'
+                    p.set(p.x + 50, p.y);
+
                     handlePoint.accept(p);
                 });
     }

--- a/app/src/main/java/bhg/sucks/helper/TapHelper.java
+++ b/app/src/main/java/bhg/sucks/helper/TapHelper.java
@@ -35,7 +35,7 @@ public class TapHelper {
     }
 
     /**
-     * Taps the button "5 Artifacts" and three more times to hurry the following animation.
+     * Taps the button "5 Artifacts" and four more times in the corner to hurry the following animation.
      */
     public void tapFiveArtifacts() {
         if (!delegate.isRunning()) {
@@ -119,7 +119,7 @@ public class TapHelper {
     }
 
     /**
-     * Taps the button "Confirm" and hurries the following animation.
+     * Taps the button "Confirm" and hurries the following animation by tapping three times in the corner.
      */
     public void tapConfirm() {
         if (!delegate.isRunning()) {
@@ -162,7 +162,7 @@ public class TapHelper {
     }
 
     /**
-     * Taps the button "Continue" and hurries the following animation.
+     * Taps the button "Continue" and hurries the following animation by tapping three times in the corner.
      */
     public void tapContinue() {
         if (!delegate.isRunning()) {
@@ -204,6 +204,9 @@ public class TapHelper {
         continueExecutor.execute();
     }
 
+    /**
+     * Hurries the animation by tapping three times in the corner.
+     */
     public boolean tapHurryAnimation() {
         if (!delegate.isRunning()) {
             return false;

--- a/app/src/main/java/bhg/sucks/thread/TappingThread.java
+++ b/app/src/main/java/bhg/sucks/thread/TappingThread.java
@@ -136,29 +136,29 @@ public class TappingThread extends Thread {
     void analyzeResult(OcrHelper.AnalysisResult ar) {
         switch (ar.getScreen()) {
             case ARTIFACT_CRAFTING_HOME:
-                Log.d(TAG, "analyzeResult > ARTIFACT_CRAFTING_HOME > Tap '5 Artifacts'");
+                Log.i(TAG, "analyzeResult > ARTIFACT_CRAFTING_HOME > Tap '5 Artifacts'");
                 tapHelper.tapFiveArtifacts();
 
                 done();
                 break;
             case ARTIFACT_CRAFT_ANIMATION:
-                Log.d(TAG, "analyzeResult > ARTIFACT_CRAFT_ANIMATION > Counter: " + counter);
+                Log.i(TAG, "analyzeResult > ARTIFACT_CRAFT_ANIMATION > Counter: " + counter);
 
                 repeat(OcrHelper.Screen.ARTIFACT_CRAFT_ANIMATION);
                 break;
             case ARTIFACT_FULLY_LOADED:
                 Boolean keepArtifact = keepArtifact(ar.getTextBlocks());
                 if (keepArtifact == null) {
-                    Log.d(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Repeat! Counter: " + counter);
+                    Log.i(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Repeat! Counter: " + counter);
 
                     repeat(OcrHelper.Screen.ARTIFACT_FULLY_LOADED);
                 } else if (keepArtifact) {
-                    Log.d(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Tap 'Continue'");
+                    Log.i(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Tap 'Continue'");
                     tapHelper.tapContinue();
 
                     done();
                 } else {
-                    Log.d(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Sell artifact");
+                    Log.i(TAG, "analyzeResult > ARTIFACT_FULLY_LOADED > Sell artifact");
                     tapHelper.tapSell();
                     tapHelper.tapConfirm();
 
@@ -166,7 +166,7 @@ public class TappingThread extends Thread {
                 }
                 break;
             case ARTIFACT_DESTROY_DIALOG:
-                Log.d(TAG, "analyzeResult > ARTIFACT_DESTROY_DIALOG > Tap 'Confirm'");
+                Log.i(TAG, "analyzeResult > ARTIFACT_DESTROY_DIALOG > Tap 'Confirm'");
                 tapHelper.tapConfirm();
 
                 done();
@@ -174,10 +174,10 @@ public class TappingThread extends Thread {
             case COULD_NOT_DETERMINE: // Intentionally jump into default case
             default:
                 if (counter.get() < 3) {
-                    Log.d(TAG, "analyzeResult > Screen could not be determined. Repeat! Counter: " + counter);
+                    Log.i(TAG, "analyzeResult > Screen could not be determined. Repeat! Counter: " + counter);
                     repeat(OcrHelper.Screen.COULD_NOT_DETERMINE);
                 } else {
-                    Log.d(TAG, "analyzeResult > Screen could not be determined. Stop thread! Counter: " + counter);
+                    Log.i(TAG, "analyzeResult > Screen could not be determined. Stop thread! Counter: " + counter);
                     delegate.setRunning(false);
                 }
                 break;

--- a/app/src/main/java/bhg/sucks/thread/TappingThreadHelper.java
+++ b/app/src/main/java/bhg/sucks/thread/TappingThreadHelper.java
@@ -18,7 +18,15 @@ import bhg.sucks.model.UpgradeResource;
 public class TappingThreadHelper {
 
     /**
-     * @return <i>true</i>, if data.level is &gt;=3
+     * In the setting, the user can decide to
+     * <ol>
+     *     <li>not keep an artefact because of its level at all</li>
+     *     <li>keep all 3* artefacts, or</li>
+     *     <li>only keep 3* artefacts needing gold/food to upgrade.</li>
+     * </ol>
+     * Depending on that setting, an artefact is evaluated, if it should be kept because of its level.
+     *
+     * @return <i>true</i>, if an artefact should be kept because of its level
      */
     boolean keepingBecauseOfLevel(OcrHelper.Data data, KeepThreeStarOption keepThreeStarOption) {
         if (keepThreeStarOption == KeepThreeStarOption.No) {
@@ -34,7 +42,10 @@ public class TappingThreadHelper {
     }
 
     /**
-     * @return <i>keepRule</i>, if data.skills matches any keep rule
+     * Matches an artefact with all defined <i>keepRules</i>.
+     *
+     * @return <i>keepRule</i>, if data.skills matches that keep rule or<br/>
+     * an empty Optional, if no keep rule matched the artefact.
      */
     Optional<KeepRule> keepingBecauseOfRule(OcrHelper.Data data, List<KeepRule> keepRules) {
         keepRuleIteration:

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,5 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=false
 org.gradle.unsafe.configuration-cache=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=false
 org.gradle.unsafe.configuration-cache=true
 android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
+android.nonTransitiveRClass=true
 android.nonFinalResIds=false


### PR DESCRIPTION
Sometimes, in the main screen of buying artefacts, the center column ("buy single artefact") is pressed instead of the right column ("buy five artefacts"). That is, because the point of the "Yes" button (to confirm selling an artefact) is laying on the center column and probably tapped once to often (when the screenshot was taken to quickly).

This fix moves the point 50 pixel to the right.